### PR TITLE
fix: vector store query

### DIFF
--- a/dist/db/documents.js
+++ b/dist/db/documents.js
@@ -78,10 +78,12 @@ function transformFilters(filters) {
     }
     let metadata = {};
     for (const key in filters) {
-        if (key == 'filenames') {
-            metadata = { ...metadata, fileId: { $in: filters[key] } };
+        if (key === 'filenames') {
+            metadata = { ...metadata, fileId: { in: filters[key] } };
         }
-        metadata = { ...metadata, key: filters[key] };
+        else {
+            metadata = { ...metadata, [key]: filters[key] };
+        }
     }
     return metadata;
 }

--- a/src/db/documents.ts
+++ b/src/db/documents.ts
@@ -133,10 +133,11 @@ function transformFilters(
   }
   let metadata: Metadata = {}
   for (const key in filters) {
-    if (key == 'filenames') {
-      metadata = { ...metadata, fileId: { $in: filters[key] } }
+    if (key === 'filenames') {
+      metadata = { ...metadata, fileId: { in: filters[key] } }
+    } else {
+      metadata = { ...metadata, [key]: filters[key] }
     }
-    metadata = { ...metadata, key: filters[key] }
   }
 
   return metadata


### PR DESCRIPTION
Before:
```
Search response w/o file filter  {
  content: 'The current price of SPDR S&P 500 ETF TRUST (SPY) is 534.66 USD.',
  sources: [ 'files/spy.pdf' ]
}
Search response w/ file filter  {
  content: 'The current price of SPY (SPDR S&P 500 ETF TRUST) is 534.66 USD.',
  sources: [ 'files/spy.pdf', 'files/charts.pdf' ]
}
Search response w/ another file filter  {
  content: 'The current price of SPDR S&P 500 ETF TRUST (SPY) is 534.66 USD.',
  sources: [ 'files/charts.pdf', 'files/spy.pdf' ]
}
```

After:

```
Search response w/o file filter  {
  content: 'The current price of SPY (SPDR S&P 500 ETF Trust) is 534.66 USD.',
  sources: [ 'files/charts.pdf', 'files/spy.pdf' ]
}
Search response w/ file filter  {
  content: 'The current price of SPY (SPDR S&P 500 ETF Trust) is 534.66 USD.',
  sources: [ 'files/spy.pdf' ]
}
Search response w/ another file filter  {
  content: "I don't have enough information to answer your query",
  sources: [ 'files/charts.pdf' ]
}
```